### PR TITLE
Bugfix for spring.factories auto configuration name

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,8 +1,8 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   me.alidg.errors.conf.ErrorsAutoConfiguration,\
   me.alidg.errors.conf.ServletErrorsAutoConfiguration,\
-  me.alidg.errors.conf.ReactiveErrorsAutoConfiguration, \
-  me.alidg.errors.conf.ServletSecurityErrorsAutoConfiguration, \
+  me.alidg.errors.conf.ReactiveErrorsAutoConfiguration,\
+  me.alidg.errors.conf.ServletSecurityErrorsAutoConfiguration,\
   me.alidg.errors.conf.ReactiveSecurityErrorsAutoConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
   me.alidg.errors.conf.ErrorsEnvironmentPostProcessor


### PR DESCRIPTION
Extra space in `spring.factories` was the culprit for the `FileNotFoundException`.

Closes #48 