### PR TITLE
Handling Max Upload Size Violations in Servlet Environments

### DIFF
--- a/src/main/java/me/alidg/errors/conf/ErrorsAutoConfiguration.java
+++ b/src/main/java/me/alidg/errors/conf/ErrorsAutoConfiguration.java
@@ -68,7 +68,8 @@ public class ErrorsAutoConfiguration {
         new SpringValidationWebErrorHandler(),
         new ConstraintViolationWebErrorHandler(),
         new AnnotatedWebErrorHandler(),
-        new TypeMismatchWebErrorHandler()
+        new TypeMismatchWebErrorHandler(),
+        new MultipartWebErrorHandler()
     );
 
     /**

--- a/src/main/java/me/alidg/errors/handlers/MultipartWebErrorHandler.java
+++ b/src/main/java/me/alidg/errors/handlers/MultipartWebErrorHandler.java
@@ -1,0 +1,60 @@
+package me.alidg.errors.handlers;
+
+import me.alidg.errors.Argument;
+import me.alidg.errors.HandledException;
+import me.alidg.errors.WebErrorHandler;
+import org.springframework.lang.NonNull;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.*;
+import static me.alidg.errors.Argument.arg;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/**
+ * Simple {@link WebErrorHandler} implementation to handle all upload related
+ * exceptions.
+ *
+ * @author Ali Dehghani
+ */
+public class MultipartWebErrorHandler implements WebErrorHandler {
+
+    /**
+     * When exceeding the maximum possible file size, this error code would be used.
+     */
+    public static final String MAX_SIZE = "web.max_request_size";
+
+    /**
+     * When a multipart controller has been called with a non-multipart request.
+     */
+    public static final String MULTIPART_EXPECTED = "web.multipart_expected";
+
+    /**
+     * Only can handle instances of {@link MultipartException}s.
+     *
+     * @param exception The exception to examine.
+     * @return {@code true} for {@link MultipartException} subclasses, {@code false} otherwise.
+     */
+    @Override
+    public boolean canHandle(Throwable exception) {
+        return exception instanceof MultipartException;
+    }
+
+    @NonNull
+    @Override
+    public HandledException handle(Throwable exception) {
+        String errorCode = MULTIPART_EXPECTED;
+        Map<String, List<Argument>> arguments = emptyMap();
+
+        if (exception instanceof MaxUploadSizeExceededException) {
+            long maxSize = ((MaxUploadSizeExceededException) exception).getMaxUploadSize();
+            errorCode = MAX_SIZE;
+            arguments = singletonMap(MAX_SIZE, singletonList(arg("max_size", maxSize)));
+        }
+
+        return new HandledException(errorCode, BAD_REQUEST, arguments);
+    }
+}

--- a/src/test/java/me/alidg/errors/conf/ErrorsAutoConfigurationIT.java
+++ b/src/test/java/me/alidg/errors/conf/ErrorsAutoConfigurationIT.java
@@ -68,10 +68,10 @@ public class ErrorsAutoConfigurationIT {
 
             // Web Error Handlers
             List<WebErrorHandler> implementations = getImplementations(errorHandlers);
-            assertImplementations(implementations, 8,
+            assertImplementations(implementations, 9,
                 SpringValidationWebErrorHandler.class, ConstraintViolationWebErrorHandler.class,
                 AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class,
-                ServletWebErrorHandler.class, SpringSecurityWebErrorHandler.class,
+                MultipartWebErrorHandler.class, ServletWebErrorHandler.class, SpringSecurityWebErrorHandler.class,
                 MissingRequestParametersWebErrorHandler.class, ResponseStatusWebErrorHandler.class
             );
 
@@ -90,9 +90,10 @@ public class ErrorsAutoConfigurationIT {
 
             // Web Error Handlers
             List<WebErrorHandler> implementations = getImplementations(errorHandlers);
-            assertImplementations(implementations, 10,
+            assertImplementations(implementations, 11,
                 SpringValidationWebErrorHandler.class, ConstraintViolationWebErrorHandler.class,
-                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class, ServletWebErrorHandler.class,
+                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class,
+                MultipartWebErrorHandler.class, ServletWebErrorHandler.class,
                 Sec.class, First.class, SpringSecurityWebErrorHandler.class,
                 MissingRequestParametersWebErrorHandler.class, ResponseStatusWebErrorHandler.class);
 
@@ -111,9 +112,10 @@ public class ErrorsAutoConfigurationIT {
 
             // Web Error Handlers
             List<WebErrorHandler> implementations = getImplementations(errorHandlers);
-            assertImplementations(implementations, 8,
+            assertImplementations(implementations, 9,
                 SpringValidationWebErrorHandler.class, ConstraintViolationWebErrorHandler.class,
-                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class, ServletWebErrorHandler.class,
+                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class,
+                MultipartWebErrorHandler.class, ServletWebErrorHandler.class,
                 SpringSecurityWebErrorHandler.class, MissingRequestParametersWebErrorHandler.class,
                 ResponseStatusWebErrorHandler.class
             );
@@ -133,9 +135,10 @@ public class ErrorsAutoConfigurationIT {
 
             // Web Error Handlers
             List<WebErrorHandler> implementations = getImplementations(errorHandlers);
-            assertImplementations(implementations, 10,
+            assertImplementations(implementations, 11,
                 SpringValidationWebErrorHandler.class, ConstraintViolationWebErrorHandler.class,
-                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class, ServletWebErrorHandler.class,
+                AnnotatedWebErrorHandler.class, TypeMismatchWebErrorHandler.class,
+                MultipartWebErrorHandler.class, ServletWebErrorHandler.class,
                 Sec.class, First.class, SpringSecurityWebErrorHandler.class,
                 MissingRequestParametersWebErrorHandler.class, ResponseStatusWebErrorHandler.class);
 

--- a/src/test/java/me/alidg/errors/servlet/ServletController.java
+++ b/src/test/java/me/alidg/errors/servlet/ServletController.java
@@ -73,6 +73,9 @@ public class ServletController {
     public void pagedResult(Pageable pageable) {
     }
 
+    @PostMapping("/max-size")
+    public void upload(@RequestPart MultipartFile file) {}
+
     protected static class Pageable {
 
         private Integer page;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,5 @@ errors.expose-arguments=always
 errors.add-fingerprint=true
 spring.main.banner-mode=off
 management.endpoints.web.exposure.include=metrics
+spring.servlet.multipart.max-file-size=1KB
+spring.servlet.multipart.max-request-size=2KB


### PR DESCRIPTION
Related to #83 #84 
Since Reactive environments do not support configuring the max upload size, we can't handle that error for them!