### PR TITLE
Create new @ExposeArg annotation that deprecates @ExposeAsArg

### DIFF
--- a/EXPOSED-ARGS.md
+++ b/EXPOSED-ARGS.md
@@ -97,28 +97,37 @@ For `Unsupported Media Type`s in the Reactive stack, we only expose all supporte
 
 ## Annotated Exceptions
 For exceptions annotated with our `@ExceptionMapping` annotation, we only expose fields or no-arg methods annotated with the
-`@ExposeAsArg` annotation. The positional argument is determined by the `value` attribute of the `ExposeAsArg`. Also, the
-named argument is the field or method name unless we provide a non-blank value using the `name` attribute.
+`@ExposeArg` annotation. The order of positional arguments is determined by:
+ 1. the `order` attribute of the `@ExposeArg`, then
+ 2. the `value` attribute of the `@ExposeArg`, then
+ 3. the name of annotated element.
+Named argument is the field or method name unless we provide a non-blank value using the `name` attribute.
 
 For example, for the following exception:
 ```java
 @ExceptionMapping(errorCode = "code", statusCode = HttpStatus.BAD_REQUEST)
 public class SomeException extends RuntimeException {
     
-    @ExposeAsArg(-1)
+    @ExposeArg(order = -1)
     private final String name;
     
-    @ExposeAsArg(value = 10, name = "num")
+    @ExposeArg(value = "num1", order = 10)
     private final Integer number;
+    
+    @ExposeArg(value = "num2", order = 10)
+    private final Integer anotherNumber;
+    
+    @ExposeArg
+    private final String lastArgument;
     
     // constructor
     
-    @ExposeAsArg(3)
+    @ExposeArg(order = 3)
     public String getSomething() {
         // implementation
     }
     
-    @ExposeAsArg(value = 6, name = "another")
+    @ExposeArg(order = 6, value = "another")
     public long getAnotherThing() {
         // implementation
     }
@@ -130,6 +139,8 @@ We expose:
 | Named Argument | Positional Index |
 |:--------------:|:----------------:|
 | `name`         | 0                |
-| `getSomething` | 1                | 
-| `another`      | 2                | 
-| `num`          | 3                | 
+| `getSomething` | 1                |
+| `another`      | 2                |
+| `num1`         | 3                |
+| `num2`         | 4                |
+| `lastArgument` | 5                |

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <quiet>true</quiet>
+                    <source>${java.version}</source>
                     <tags>
                         <tag>
                             <name>apiNote</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
-        <java.version>1.8</java.version>
+        <spring-boot.version>2.5.3</spring-boot.version>
+        <java.version>11</java.version>
         <junitparams.version>1.1.1</junitparams.version>
         <jacoco.version>0.8.5</jacoco.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -73,7 +73,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <spring-security-test.version>5.2.0.RELEASE</spring-security-test.version>
+        <spring-security-test.version>5.5.2</spring-security-test.version>
     </properties>
 
     <dependencies>
@@ -102,6 +102,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>${jsr305.version}</version>
@@ -117,12 +123,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <version>${spring-security-test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
-            <version>${junitparams.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/alidg/errors/adapter/attributes/Exceptions.java
+++ b/src/main/java/me/alidg/errors/adapter/attributes/Exceptions.java
@@ -1,7 +1,7 @@
 package me.alidg.errors.adapter.attributes;
 
 import me.alidg.errors.annotation.ExceptionMapping;
-import me.alidg.errors.annotation.ExposeAsArg;
+import me.alidg.errors.annotation.ExposeArg;
 
 import java.util.Map;
 
@@ -70,7 +70,7 @@ class Exceptions {
         /**
          * The to-be-exposed path.
          */
-        @ExposeAsArg(0)
+        @ExposeArg
         @SuppressWarnings("FieldCanBeLocal")
         private final String path;
 

--- a/src/main/java/me/alidg/errors/adapter/attributes/ReactiveErrorAttributes.java
+++ b/src/main/java/me/alidg/errors/adapter/attributes/ReactiveErrorAttributes.java
@@ -3,6 +3,7 @@ package me.alidg.errors.adapter.attributes;
 import me.alidg.errors.HttpError;
 import me.alidg.errors.WebErrorHandlers;
 import me.alidg.errors.adapter.HttpErrorAttributesAdapter;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
@@ -42,7 +43,6 @@ public class ReactiveErrorAttributes extends DefaultErrorAttributes {
      */
     public ReactiveErrorAttributes(WebErrorHandlers webErrorHandlers,
                                    HttpErrorAttributesAdapter httpErrorAttributesAdapter) {
-        super(true);
         this.webErrorHandlers = requireNonNull(webErrorHandlers, "Web error handlers is required");
         this.httpErrorAttributesAdapter = requireNonNull(httpErrorAttributesAdapter, "Adapter is required");
     }
@@ -50,14 +50,10 @@ public class ReactiveErrorAttributes extends DefaultErrorAttributes {
     /**
      * Handles the exception by delegating it to the {@link #webErrorHandlers} and then adapting
      * the representation.
-     *
-     * @param request           The source request.
-     * @param includeStackTrace whether to include the error stacktrace information.
-     * @return A map of error attributes
      */
     @Override
-    public Map<String, Object> getErrorAttributes(ServerRequest request, boolean includeStackTrace) {
-        Map<String, Object> attributes = super.getErrorAttributes(request, includeStackTrace);
+    public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
+        Map<String, Object> attributes = super.getErrorAttributes(request, options);
         Throwable exception = getError(request);
         if (exception == null || isNotFoundException(exception))
             exception = Exceptions.refineUnknownException(attributes);

--- a/src/main/java/me/alidg/errors/adapter/attributes/ServletErrorAttributes.java
+++ b/src/main/java/me/alidg/errors/adapter/attributes/ServletErrorAttributes.java
@@ -3,6 +3,7 @@ package me.alidg.errors.adapter.attributes;
 import me.alidg.errors.HttpError;
 import me.alidg.errors.WebErrorHandlers;
 import me.alidg.errors.adapter.HttpErrorAttributesAdapter;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.web.context.request.WebRequest;
 
@@ -60,14 +61,10 @@ public class ServletErrorAttributes extends DefaultErrorAttributes {
      * status code and tries its best to find an exception related to that status code. Finally, handles
      * the exception using the {@link #webErrorHandlers} and adapts the returned {@link HttpError} to a
      * Spring Boot compatible representation.
-     *
-     * @param webRequest        The current HTTP request.
-     * @param includeStackTrace Whether or not to include the stack trace in the error attributes.
-     * @return Error details.
      */
     @Override
-    public Map<String, Object> getErrorAttributes(WebRequest webRequest, boolean includeStackTrace) {
-        Map<String, Object> attributes = super.getErrorAttributes(webRequest, includeStackTrace);
+    public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
+        Map<String, Object> attributes = super.getErrorAttributes(webRequest, options);
         Throwable exception = getError(webRequest);
         if (exception == null) exception = Exceptions.refineUnknownException(attributes);
 

--- a/src/main/java/me/alidg/errors/annotation/ExceptionMapping.java
+++ b/src/main/java/me/alidg/errors/annotation/ExceptionMapping.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
  * error code/status code combination.
  *
  * @author Ali Dehghani
- * @see ExposeAsArg
+ * @see ExposeArg
  * @see me.alidg.errors.handlers.AnnotatedWebErrorHandler
  */
 @Inherited

--- a/src/main/java/me/alidg/errors/annotation/ExposeArg.java
+++ b/src/main/java/me/alidg/errors/annotation/ExposeArg.java
@@ -11,48 +11,43 @@ import java.lang.annotation.*;
  *
  *     &#64;ExceptionMapping(statusCode=BAD_REQUEST, errorCode="user.exists")
  *     public class UserExistsException extends RuntimeException {
- *         &#64;ExposeAsArg(0) private final String username;
+ *         &#64;ExposeArg private final String username;
  *
  *         // constructor and etc.
  *     }
  * </pre>
  * With this setting, when the exception happens, the {@link me.alidg.errors.handlers.AnnotatedWebErrorHandler}
  * would pick the error code from the annotation and find an appropriate message for the error code.
- * By annotating the {@code username} property with the {@link ExposeAsArg} annotation, we can use the username
+ * By annotating the {@code username} property with the {@link ExposeArg} annotation, we can use the username
  * value to report it in the translated error message:
  * <pre>
  *
- *     user.exists=Another user with {0} username is already exists.
+ *     user.exists=Another user with {username} username is already exists.
  * </pre>
- * When interpolating the error message from the error code, the {@code {0}} would be replaced
- * with the username value exposed with:
+ * When interpolating the error message from the error code, the {@code {username}} would be replaced
+ * with the value of {@code username} value exposed with:
  * <pre>
  *
- *     &#64;ExposeAsArg(0) private final String username;
+ *     &#64;ExposeArg private final String username;
  * </pre>
+ * <p>
+ * This annotation has precedence over {@link ExposeAsArg} when both are used on the same element.
  *
- * @author Ali Dehghani
+ * @author zarebski.m
  * @see ExceptionMapping
+ * @see ExposeAsArg
  * @see me.alidg.errors.handlers.AnnotatedWebErrorHandler
- * @deprecated Use {@link ExposeArg} instead.
  */
-@Deprecated
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-public @interface ExposeAsArg {
-
-    /**
-     * Determines the index of the to-be-exposed argument.
-     *
-     * @return The argument index.
-     */
-    int value();
-
+public @interface ExposeArg {
     /**
      * If the arguments are meant to be exposed, then overrides the to-be-exposed name.
      *
      * @return The to-be-exposed name.
      */
-    String name() default "";
+    String value() default "";
+
+    int order() default Integer.MAX_VALUE;
 }

--- a/src/main/java/me/alidg/errors/conf/ServletErrorsAutoConfiguration.java
+++ b/src/main/java/me/alidg/errors/conf/ServletErrorsAutoConfiguration.java
@@ -107,7 +107,7 @@ public class ServletErrorsAutoConfiguration {
         /**
          * Since our custom {@link ErrorAttributes} implementation is storing the HTTP status code inside
          * the HTTP request, we should call the {@link #getStatus(HttpServletRequest)} method after the
-         * call to {@link #getErrorAttributes(HttpServletRequest, boolean)}.
+         * call to {@link #getErrorAttributeOptions(HttpServletRequest, org.springframework.http.MediaType)}.
          *
          * @param request The current HTTP request.
          * @return Returns the HTTP response.
@@ -115,7 +115,7 @@ public class ServletErrorsAutoConfiguration {
         @Override
         @RequestMapping
         public ResponseEntity<Map<String, Object>> error(HttpServletRequest request) {
-            Map<String, Object> body = getErrorAttributes(request, isIncludeStackTrace(request, ALL));
+            Map<String, Object> body = getErrorAttributes(request, getErrorAttributeOptions(request, ALL));
             HttpStatus status = getStatus(request);
             return new ResponseEntity<>(body, status);
         }

--- a/src/main/java/me/alidg/errors/handlers/AnnotatedWebErrorHandler.java
+++ b/src/main/java/me/alidg/errors/handlers/AnnotatedWebErrorHandler.java
@@ -4,14 +4,13 @@ import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
 import me.alidg.errors.annotation.ExceptionMapping;
+import me.alidg.errors.annotation.ExposeArg;
 import me.alidg.errors.annotation.ExposeAsArg;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -19,27 +18,40 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static me.alidg.errors.Argument.arg;
 
 /**
  * {@link WebErrorHandler} implementation responsible for handling exceptions annotated with
  * the {@link ExceptionMapping} annotation. The web error code and status code would be
- * extracted form the annotated exception. Also, any member annotated with {@link ExposeAsArg}
- * would be exposed as arguments.
+ * extracted form the annotated exception. Also, any member annotated with {@link ExposeArg}
+ * or {@link ExposeAsArg} would be exposed as arguments.
  *
  * @author Ali Dehghani
+ * @see ExposeArg
  * @see ExposeAsArg
  * @see ExceptionMapping
  */
 public class AnnotatedWebErrorHandler implements WebErrorHandler {
 
     /**
-     * Helps us to sort different elements annotated with {@link ExposeAsArg} based on their
-     * {@link ExposeAsArg#value()}.
+     * Helps us to sort different elements annotated with {@link ExposeArg} based on their
+     * {@link ExposeArg#order()}.
      */
-    private final Comparator<AnnotatedElement> byExposedIndex =
-        Comparator.comparing(e -> e.getAnnotation(ExposeAsArg.class).value());
+    private static final Comparator<AccessibleObject> byExposedIndex = Comparator
+        .comparing((AccessibleObject o) -> requireNonNull(getExposeAnnotation(o)).order())
+        .thenComparing(o -> requireNonNull(getExposeAnnotation(o)).value())
+        .thenComparing(AnnotatedWebErrorHandler::objectName);
+
+    private static String objectName(AccessibleObject o) {
+        if (o instanceof Field) {
+            return ((Field) o).getName();
+        } else if (o instanceof Method) {
+            return ((Method) o).getName();
+        }
+        return "";
+    }
 
     /**
      * Only can handle non-null exceptions annotated with {@link ExceptionMapping} annotation.
@@ -58,7 +70,7 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
     /**
      * Handles the thrown exception annotated with {@link ExceptionMapping} by using the
      * {@link ExceptionMapping#errorCode()} as the error code, the {@link ExceptionMapping#statusCode()}
-     * as the HTTP status code and also, exposing exception members annotated with {@link ExposeAsArg}.
+     * as the HTTP status code and also, exposing exception members annotated with {@link ExposeArg}.
      *
      * @param exception The exception to handle.
      * @return An {@link HandledException} instance encapsulating the error code, status code and
@@ -76,14 +88,14 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
     }
 
     /**
-     * Finds all fields and methods annotated with {@link ExposeAsArg} and return their value or
-     * return value as to-be-exposed arguments.
+     * Finds all fields and methods annotated with {@link ExposeArg} and return
+     * their value or return value as to-be-exposed arguments.
      *
      * @param exception The exception to extract the members from.
      * @return Array of exposed arguments.
      */
     private List<Argument> getExposedValues(Throwable exception) {
-        List<AnnotatedElement> members = new ArrayList<>();
+        List<AccessibleObject> members = new ArrayList<>();
         members.addAll(getExposedFields(exception));
         members.addAll(getExposedMethods(exception));
         members.sort(byExposedIndex);
@@ -96,13 +108,13 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
     }
 
     /**
-     * Given an element annotated with {@link ExposeAsArg}
+     * Given an element annotated with {@link ExposeArg}
      *
      * @param element   The field or method we're going to extract its value.
      * @param exception The containing exception that those fields or methods are declared in.
      * @return The field value or method return value.
      */
-    private Argument getArgument(AnnotatedElement element, Throwable exception) {
+    private Argument getArgument(AccessibleObject element, Throwable exception) {
         try {
             if (element instanceof Field) {
                 Field f = (Field) element;
@@ -123,31 +135,31 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
 
     /**
      * Returns all fields declared in the given {@code exception} that annotated with the
-     * {@link ExposeAsArg} annotation.
+     * {@link ExposeArg} or {@link ExposeAsArg} annotation.
      *
      * @param exception The exception reflect on.
      * @return List of all annotated fields.
      */
     private List<Field> getExposedFields(Throwable exception) {
         return Stream.of(exception.getClass().getDeclaredFields())
-            .filter(f -> f.isAnnotationPresent(ExposeAsArg.class))
+            .filter(this::exposeAnnotationIsPresent)
             .collect(toList());
     }
 
     /**
-     * All methods (with a return type and no parameters) annotated with the {@link ExposeAsArg} annotation.
+     * All methods (with a return type and no parameters) annotated with the {@link ExposeArg} annotation.
      *
      * @param exception The exception reflect on.
      * @return List of all annotated methods.
      */
     private List<Method> getExposedMethods(Throwable exception) {
         return Stream.of(exception.getClass().getMethods())
-            .filter(m -> annotationIsPresent(m) && hasReturnType(m) && hasNoParameters(m))
+            .filter(m -> exposeAnnotationIsPresent(m) && hasReturnType(m) && hasNoParameters(m))
             .collect(toList());
     }
 
     /**
-     * Returns the to-be-exposed name. If the {@link ExposeAsArg#name()} is not blank, then
+     * Returns the to-be-exposed name. If the {@link ExposeArg#value()} is not blank, then
      * it would be the exposed name. Otherwise, we use the {@link Member#getName()} as that name.
      *
      * @param member The exception member.
@@ -155,12 +167,46 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
      * @return The to-be-exposed name.
      */
     private <T extends AnnotatedElement & Member> String getExposedName(T member) {
-        ExposeAsArg annotation = member.getAnnotation(ExposeAsArg.class);
-        if (annotation != null && !annotation.name().trim().isEmpty()) {
-            return annotation.name();
+        ExposeArg annotation = getExposeAnnotation(member);
+        if (annotation != null && !annotation.value().trim().isEmpty()) {
+            return annotation.value();
         }
 
         return member.getName();
+    }
+
+    /**
+     * Returns instance of {@link ExposeArg} annotation. If this annotation is found on given member,
+     * it is simply returned. If {@link ExposeAsArg} annotation is present instead, method returns
+     * instance of {@link ExposeArg} migrated from deprecated {@link ExposeAsArg} annotation.
+     *
+     * @param member The exception member.
+     * @return Instance of {@link ExposeArg} annotation, migrated from deprecated {@link ExposeAsArg} if necessary.
+     */
+    @SuppressWarnings("deprecation")
+    private static ExposeArg getExposeAnnotation(AnnotatedElement member) {
+        ExposeArg annotation = member.getAnnotation(ExposeArg.class);
+        if (annotation != null) return annotation;
+        ExposeAsArg legacyAnnotation = member.getAnnotation(ExposeAsArg.class);
+        if (legacyAnnotation != null) {
+            return new ExposeArg() {
+                @Override
+                public String value() {
+                    return legacyAnnotation.name();
+                }
+
+                @Override
+                public int order() {
+                    return legacyAnnotation.value();
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return ExposeArg.class;
+                }
+            };
+        }
+        return null;
     }
 
     private boolean hasNoParameters(Method m) {
@@ -171,7 +217,8 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
         return m.getReturnType() != Void.TYPE;
     }
 
-    private boolean annotationIsPresent(Method m) {
-        return m.isAnnotationPresent(ExposeAsArg.class);
+    @SuppressWarnings("deprecation")
+    private boolean exposeAnnotationIsPresent(AccessibleObject m) {
+        return m.isAnnotationPresent(ExposeArg.class) || m.isAnnotationPresent(ExposeAsArg.class);
     }
 }

--- a/src/main/java/me/alidg/errors/handlers/AnnotatedWebErrorHandler.java
+++ b/src/main/java/me/alidg/errors/handlers/AnnotatedWebErrorHandler.java
@@ -26,11 +26,10 @@ import static me.alidg.errors.Argument.arg;
  * {@link WebErrorHandler} implementation responsible for handling exceptions annotated with
  * the {@link ExceptionMapping} annotation. The web error code and status code would be
  * extracted form the annotated exception. Also, any member annotated with {@link ExposeArg}
- * or {@link ExposeAsArg} would be exposed as arguments.
+ * would be exposed as arguments.
  *
  * @author Ali Dehghani
  * @see ExposeArg
- * @see ExposeAsArg
  * @see ExceptionMapping
  */
 public class AnnotatedWebErrorHandler implements WebErrorHandler {
@@ -135,7 +134,7 @@ public class AnnotatedWebErrorHandler implements WebErrorHandler {
 
     /**
      * Returns all fields declared in the given {@code exception} that annotated with the
-     * {@link ExposeArg} or {@link ExposeAsArg} annotation.
+     * {@link ExposeArg} annotation.
      *
      * @param exception The exception reflect on.
      * @return List of all annotated fields.

--- a/src/main/java/me/alidg/errors/handlers/ConstraintViolations.java
+++ b/src/main/java/me/alidg/errors/handlers/ConstraintViolations.java
@@ -1,7 +1,10 @@
 package me.alidg.errors.handlers;
 
 import me.alidg.errors.Argument;
-import org.hibernate.validator.constraints.*;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+import org.hibernate.validator.constraints.URL;
+import org.hibernate.validator.constraints.UniqueElements;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.constraints.*;
@@ -117,7 +120,6 @@ final class ConstraintViolations {
         // Hibernate Validator Specific Constraints
         codes.put(URL.class, "invalidUrl");
         codes.put(UniqueElements.class, "shouldBeUnique");
-        codes.put(SafeHtml.class, "unsafeHtml");
         codes.put(Range.class, "outOfRange");
         codes.put(Length.class, "invalidSize");
 

--- a/src/test/java/me/alidg/errors/EqualsAndHashCodeTest.java
+++ b/src/test/java/me/alidg/errors/EqualsAndHashCodeTest.java
@@ -1,9 +1,7 @@
 package me.alidg.errors;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -14,11 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Generic unit test that checks equals and hashCode contract.
  */
-@RunWith(JUnitParamsRunner.class)
 public class EqualsAndHashCodeTest {
 
-    @Test
-    @Parameters(method = "provideParams")
+    @ParameterizedTest
+    @MethodSource("provideParams")
     public void testEqualsAndHashCode(Object obj, Object equalObj, Object notEqualObj) {
         assertThat(obj).isNotEqualTo(null);
         assertThat(obj).isEqualTo(obj);
@@ -28,7 +25,7 @@ public class EqualsAndHashCodeTest {
         assertThat(obj.hashCode()).isEqualTo(equalObj.hashCode());
     }
 
-    private Object[] provideParams() {
+    private static Object[] provideParams() {
         return p(
             p(arg("name", "value"), arg("name", "value"), arg("differentName", "differentValue")),
             p(

--- a/src/test/java/me/alidg/errors/HandledExceptionTest.java
+++ b/src/test/java/me/alidg/errors/HandledExceptionTest.java
@@ -1,9 +1,7 @@
 package me.alidg.errors;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 import java.util.HashSet;
@@ -23,11 +21,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class HandledExceptionTest {
 
-    @Test
-    @Parameters(method = "provideParamsForPrimary")
+    @ParameterizedTest
+    @MethodSource("provideParamsForPrimary")
     public void primaryConstructor_ShouldEnforceItsPreconditions(Set<String> errorCodes,
                                                                  HttpStatus status,
                                                                  Class<? extends Throwable> expected,
@@ -37,8 +34,8 @@ public class HandledExceptionTest {
             .hasMessage(message);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForSecondary")
+    @ParameterizedTest
+    @MethodSource( "provideParamsForSecondary")
     public void secondConstructor_ShouldEnforceItsPreconditions(String errorCode,
                                                                 HttpStatus status,
                                                                 Class<? extends Throwable> expected,
@@ -48,8 +45,8 @@ public class HandledExceptionTest {
             .hasMessage(message);
     }
 
-    @Test
-    @Parameters(method = "provideMaps")
+    @ParameterizedTest
+    @MethodSource( "provideMaps")
     public void constructors_ShouldSetNullArgumentsAsEmptyMaps(Map<String, List<Argument>> provided,
                                                                Map<?, ?> expected) {
         assertThat(new HandledException(singleton("error"), BAD_REQUEST, provided).getArguments())
@@ -59,7 +56,7 @@ public class HandledExceptionTest {
             .isEqualTo(expected);
     }
 
-    private Object[] provideParamsForPrimary() {
+    private static Object[] provideParamsForPrimary() {
         return p(
             p(null, null, NullPointerException.class, "Error codes is required"),
             p(new HashSet<>(asList("", "", null)), null, NullPointerException.class, "Status code is required"),
@@ -68,7 +65,7 @@ public class HandledExceptionTest {
         );
     }
 
-    private Object[] provideParamsForSecondary() {
+    private static Object[] provideParamsForSecondary() {
         return p(
             p(null, null, NullPointerException.class, "Status code is required"),
             p("error", null, NullPointerException.class, "Status code is required"),
@@ -76,7 +73,7 @@ public class HandledExceptionTest {
         );
     }
 
-    private Object[] provideMaps() {
+    private static Object[] provideMaps() {
         return p(
             p(null, emptyMap()),
             p(singletonMap("key", emptyList()), singletonMap("key", emptyList()))

--- a/src/test/java/me/alidg/errors/WebErrorHandlersTest.java
+++ b/src/test/java/me/alidg/errors/WebErrorHandlersTest.java
@@ -1,9 +1,7 @@
 package me.alidg.errors;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.context.MessageSource;
 
 import java.util.List;
@@ -18,12 +16,11 @@ import static org.mockito.Mockito.mock;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class WebErrorHandlersTest {
 
-    @Test
+    @ParameterizedTest
     @SuppressWarnings("deprecation")
-    @Parameters(method = "paramsForConstructor")
+    @MethodSource("paramsForConstructor")
     public void constructor_ShouldEnforceItsPreconditions(MessageSource messageSource,
                                                           List<WebErrorHandler> handlers,
                                                           Class<? extends Throwable> expectedException,
@@ -33,7 +30,7 @@ public class WebErrorHandlersTest {
             .hasMessage(expectedMessage);
     }
 
-    private Object[] paramsForConstructor() {
+    private static Object[] paramsForConstructor() {
         return p(
             p(null, null, NullPointerException.class, "We need a MessageSource implementation to message translation"),
             p(mock(MessageSource.class), null, NullPointerException.class, "Collection of error handlers is required"),

--- a/src/test/java/me/alidg/errors/adapter/DefaultHttpErrorAttributesAdapterTest.java
+++ b/src/test/java/me/alidg/errors/adapter/DefaultHttpErrorAttributesAdapterTest.java
@@ -1,13 +1,12 @@
 package me.alidg.errors.adapter;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HttpError;
 import me.alidg.errors.conf.ErrorsProperties;
 import me.alidg.errors.conf.ErrorsProperties.ArgumentExposure;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.entry;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class DefaultHttpErrorAttributesAdapterTest {
 
     @Test
@@ -61,8 +59,8 @@ public class DefaultHttpErrorAttributesAdapterTest {
         assertThat(adapted).contains(entry("fingerprint", "fingerprint"));
     }
 
-    @Test
-    @Parameters(method = "provideExposureParams")
+    @ParameterizedTest
+    @MethodSource("provideExposureParams")
     @SuppressWarnings("unchecked")
     public void adapt_ShouldAdaptTheHttpErrorWithArgumentsToAMapProperly(
         ArgumentExposure exposure,
@@ -83,7 +81,7 @@ public class DefaultHttpErrorAttributesAdapterTest {
         assertThat(errors.get(0).containsKey("arguments")).isEqualTo(parametersFieldPresent);
     }
 
-    private Object[] provideExposureParams() {
+    private static Object[] provideExposureParams() {
         return p(
             p(ArgumentExposure.NEVER, emptyList(), false),
             p(ArgumentExposure.NEVER, singletonList(arg("name", "value")), false),

--- a/src/test/java/me/alidg/errors/adapter/attributes/ExceptionsTest.java
+++ b/src/test/java/me/alidg/errors/adapter/attributes/ExceptionsTest.java
@@ -1,9 +1,7 @@
 package me.alidg.errors.adapter.attributes;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,11 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class ExceptionsTest {
 
-    @Test
-    @Parameters(method = "provideParams")
+    @ParameterizedTest
+    @MethodSource("provideParams")
     public void refineUnknownException_ShouldMapTheStatusCodeToExceptionAsExpected(Object code, String expected) {
         Map<String, Object> attributes = null;
         if (code != null) {
@@ -28,12 +25,11 @@ public class ExceptionsTest {
             attributes.put("status", code);
         }
 
-
         assertThat(Exceptions.refineUnknownException(attributes).getClass().getSimpleName())
             .isEqualTo(expected);
     }
 
-    private Object[] provideParams() {
+    private static Object[] provideParams() {
         return p(
             p("dqd", "IllegalStateException"),
             p(null, "IllegalStateException"),

--- a/src/test/java/me/alidg/errors/adapter/attributes/ServletErrorAttributesIT.java
+++ b/src/test/java/me/alidg/errors/adapter/attributes/ServletErrorAttributesIT.java
@@ -1,19 +1,14 @@
 package me.alidg.errors.adapter.attributes;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.servlet.ServletApplication;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -33,24 +28,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ali Dehghani
  */
 @AutoConfigureMockMvc
-@RunWith(JUnitParamsRunner.class)
 @SpringBootTest(classes = ServletApplication.class, webEnvironment = RANDOM_PORT)
 public class ServletErrorAttributesIT {
-
-    @ClassRule
-    public static final SpringClassRule springClassRule = new SpringClassRule();
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
     /**
      * To perform web requests.
      */
     @Autowired
     private MockMvc mvc;
 
-    @Test
-    @Parameters(method = "dataForDifferentErrorScenarios")
+    @ParameterizedTest
+    @MethodSource("dataForDifferentErrorScenarios")
     public void getErrorAttributes_ShouldExtractAndHandlesErrorsProperly(Throwable exception,
                                                                          int statusCode,
                                                                          int expectedStatusCode,
@@ -83,7 +70,7 @@ public class ServletErrorAttributesIT {
             .andExpect(jsonPath("$.errors[0].arguments.path").value("unknown"));
     }
 
-    private Object[] dataForDifferentErrorScenarios() {
+    private static Object[] dataForDifferentErrorScenarios() {
         return p(
             p(new AccessDeniedException(""), 0, 403, ACCESS_DENIED, null),
             p(new AccessDeniedException(""), 403, 403, ACCESS_DENIED, null),

--- a/src/test/java/me/alidg/errors/adapter/attributes/ServletErrorAttributesTest.java
+++ b/src/test/java/me/alidg/errors/adapter/attributes/ServletErrorAttributesTest.java
@@ -1,11 +1,9 @@
 package me.alidg.errors.adapter.attributes;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.WebErrorHandlers;
 import me.alidg.errors.adapter.HttpErrorAttributesAdapter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static me.alidg.Params.p;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,11 +14,10 @@ import static org.mockito.Mockito.mock;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class ServletErrorAttributesTest {
 
-    @Test
-    @Parameters(method = "provideInvalidParamsToConstructor")
+    @ParameterizedTest
+    @MethodSource("provideInvalidParamsToConstructor")
     public void constructor_ShouldEnforceItsPreconditions(WebErrorHandlers handlers,
                                                           HttpErrorAttributesAdapter adapter,
                                                           Class<? extends Throwable> expectedException,
@@ -30,7 +27,7 @@ public class ServletErrorAttributesTest {
             .hasMessage(expectedMessage);
     }
 
-    private Object[] provideInvalidParamsToConstructor() {
+    private static Object[] provideInvalidParamsToConstructor() {
         return p(
             p(null, null, NullPointerException.class, "Web error handlers is required"),
             p(mock(WebErrorHandlers.class), null, NullPointerException.class, "Adapter is required")

--- a/src/test/java/me/alidg/errors/annotation/AutoConfigureErrorsIT.java
+++ b/src/test/java/me/alidg/errors/annotation/AutoConfigureErrorsIT.java
@@ -2,7 +2,7 @@ package me.alidg.errors.annotation;
 
 import me.alidg.errors.WebErrorHandlers;
 import me.alidg.errors.conf.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration;

--- a/src/test/java/me/alidg/errors/conf/ErrorsAutoConfigurationIT.java
+++ b/src/test/java/me/alidg/errors/conf/ErrorsAutoConfigurationIT.java
@@ -1,7 +1,5 @@
 package me.alidg.errors.conf;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
 import me.alidg.errors.WebErrorHandlers;
@@ -9,8 +7,9 @@ import me.alidg.errors.adapter.DefaultHttpErrorAttributesAdapter;
 import me.alidg.errors.adapter.HttpErrorAttributesAdapter;
 import me.alidg.errors.conf.ErrorsProperties.ArgumentExposure;
 import me.alidg.errors.handlers.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -34,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class ErrorsAutoConfigurationIT {
 
     private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
@@ -178,8 +176,8 @@ public class ErrorsAutoConfigurationIT {
         });
     }
 
-    @Test
-    @Parameters(method = "provideExposures")
+    @ParameterizedTest
+    @MethodSource("provideExposures")
     public void withProperties_ErrorsPropertiesBeanIsConfigurable(String value, ArgumentExposure expected) {
         contextRunner.withPropertyValues("errors.expose-arguments=" + value).run(ctx -> {
             ErrorsProperties properties = ctx.getBean(ErrorsProperties.class);
@@ -189,7 +187,7 @@ public class ErrorsAutoConfigurationIT {
         });
     }
 
-    private Object[] provideExposures() {
+    private static Object[] provideExposures() {
         return p(
             p("ALWAYS¨", ArgumentExposure.ALWAYS),
             p("always¨", ArgumentExposure.ALWAYS),
@@ -207,9 +205,9 @@ public class ErrorsAutoConfigurationIT {
     }
 
     @SafeVarargs
-    private final void assertImplementations(List<WebErrorHandler> actualHandlers,
-                                             int expectedSize,
-                                             Class<? extends WebErrorHandler>... expectedTypes) {
+    private void assertImplementations(List<WebErrorHandler> actualHandlers,
+                                       int expectedSize,
+                                       Class<? extends WebErrorHandler>... expectedTypes) {
         assertThat(actualHandlers).hasSize(expectedSize);
         for (int i = 0; i < expectedTypes.length; i++) {
             assertThat(actualHandlers.get(i)).isInstanceOf(expectedTypes[i]);

--- a/src/test/java/me/alidg/errors/fingerprint/Md5FingerprintProviderTest.java
+++ b/src/test/java/me/alidg/errors/fingerprint/Md5FingerprintProviderTest.java
@@ -1,7 +1,7 @@
 package me.alidg.errors.fingerprint;
 
 import me.alidg.errors.HttpError;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/test/java/me/alidg/errors/handlers/AnnotatedWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/AnnotatedWebErrorHandlerTest.java
@@ -1,14 +1,12 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.annotation.ExceptionMapping;
 import me.alidg.errors.annotation.ExposeArg;
 import me.alidg.errors.annotation.ExposeAsArg;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collections;
@@ -25,7 +23,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class AnnotatedWebErrorHandlerTest {
 
     /**
@@ -33,16 +30,16 @@ public class AnnotatedWebErrorHandlerTest {
      */
     private final AnnotatedWebErrorHandler handler = new AnnotatedWebErrorHandler();
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_ShouldOnlyReturnTrueForExceptionsAnnotatedWithExceptionMapping(Exception exception,
                                                                                          boolean expected) {
         assertThat(handler.canHandle(exception))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldProperlyHandleTheGivenException(Exception exception,
                                                              String code,
                                                              HttpStatus status,
@@ -56,7 +53,7 @@ public class AnnotatedWebErrorHandlerTest {
         assertThat((handled.getArguments().get(code))).isEqualTo(args);
     }
 
-    private Object[] provideParamsForCanHandle() {
+    private static Object[] provideParamsForCanHandle() {
         return p(
             p(null, false),
             p(new NotAnnotated(), false),
@@ -65,7 +62,7 @@ public class AnnotatedWebErrorHandlerTest {
         );
     }
 
-    private Object[] provideParamsForHandle() {
+    private static Object[] provideParamsForHandle() {
         return p(
             p(
                 new Annotated("f", "s"),
@@ -100,15 +97,15 @@ public class AnnotatedWebErrorHandlerTest {
 
     // Auxiliary exception definitions!
 
-    private class NotAnnotated extends RuntimeException {
+    private static class NotAnnotated extends RuntimeException {
     }
 
     @ExceptionMapping(statusCode = BAD_REQUEST, errorCode = "no_exposed")
-    private class NoExposedArgs extends RuntimeException {
+    private static class NoExposedArgs extends RuntimeException {
     }
 
     @ExceptionMapping(statusCode = BAD_REQUEST, errorCode = "annotated")
-    private class Annotated extends RuntimeException {
+    private static class Annotated extends RuntimeException {
 
         @ExposeAsArg(value = -1, name = "some_value")
         private final String someValue;
@@ -144,7 +141,7 @@ public class AnnotatedWebErrorHandlerTest {
         }
     }
 
-    private class Inherited extends Annotated {
+    private static class Inherited extends Annotated {
         private Inherited() {
             super("f", "s");
         }

--- a/src/test/java/me/alidg/errors/handlers/AnnotatedWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/AnnotatedWebErrorHandlerTest.java
@@ -5,6 +5,7 @@ import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.annotation.ExceptionMapping;
+import me.alidg.errors.annotation.ExposeArg;
 import me.alidg.errors.annotation.ExposeAsArg;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,15 +67,34 @@ public class AnnotatedWebErrorHandlerTest {
 
     private Object[] provideParamsForHandle() {
         return p(
-            p(new Annotated("f", "s"), "annotated", BAD_REQUEST, asList(
-                arg("staticExposure", "42"),
-                arg("some_value", "f"),
-                arg("other", "s"))),
-            p(new Inherited(), "annotated", BAD_REQUEST, asList(
-                arg("staticExposure", "42"),
-                arg("random", "random"),
-                arg("other", "s"))),
-            p(new NoExposedArgs(), "no_exposed", BAD_REQUEST, Collections.emptyList())
+            p(
+                new Annotated("f", "s"),
+                "annotated",
+                BAD_REQUEST,
+                asList(
+                    arg("staticExposure", "42"),
+                    arg("some_value", "f"),
+                    arg("other", "s"),
+                    arg("otherWithNewAnnotation", "s")
+                )
+            ),
+            p(
+                new Inherited(),
+                "annotated",
+                BAD_REQUEST,
+                asList(
+                    arg("staticExposure", "42"),
+                    arg("random", "random"),
+                    arg("other", "s"),
+                    arg("otherWithNewAnnotation", "s")
+                )
+            ),
+            p(
+                new NoExposedArgs(),
+                "no_exposed",
+                BAD_REQUEST,
+                Collections.emptyList()
+            )
         );
     }
 
@@ -115,6 +135,11 @@ public class AnnotatedWebErrorHandlerTest {
 
         @ExposeAsArg(value = 100, name = "other")
         public String getOther() {
+            return other;
+        }
+
+        @ExposeArg
+        public String otherWithNewAnnotation() {
             return other;
         }
     }

--- a/src/test/java/me/alidg/errors/handlers/ClassesTest.java
+++ b/src/test/java/me/alidg/errors/handlers/ClassesTest.java
@@ -1,7 +1,7 @@
 package me.alidg.errors.handlers;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClassesTest {
 

--- a/src/test/java/me/alidg/errors/handlers/ConstraintViolationWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/ConstraintViolationWebErrorHandlerTest.java
@@ -1,12 +1,11 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 import javax.validation.ConstraintViolation;
@@ -33,7 +32,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ConstraintViolationWebErrorHandlerTest {
 
     /**
@@ -46,15 +45,15 @@ public class ConstraintViolationWebErrorHandlerTest {
      */
     private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_ShouldOnlyReturnTrueForViolationExceptionsWithAtLeastOneViolation(Exception exception,
                                                                                             boolean expected) {
         assertThat(handler.canHandle(exception)).isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldHandleViolationExceptionsProperly(ConstraintViolationException exception,
                                                                Set<String> errorCodes,
                                                                Map<String, List<Argument>> arguments) {

--- a/src/test/java/me/alidg/errors/handlers/LastResortWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/LastResortWebErrorHandlerTest.java
@@ -1,11 +1,9 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 import static java.util.Collections.singleton;
@@ -19,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
 public class LastResortWebErrorHandlerTest {
 
     /**
@@ -27,15 +24,15 @@ public class LastResortWebErrorHandlerTest {
      */
     private final WebErrorHandler handler = INSTANCE;
 
-    @Test
-    @Parameters(method = "provideParams")
+    @ParameterizedTest
+    @MethodSource("provideParams")
     public void canHandle_AlwaysReturnsFalse(Throwable exception) {
         assertThat(handler.canHandle(exception))
             .isFalse();
     }
 
-    @Test
-    @Parameters(method = "provideParams")
+    @ParameterizedTest
+    @MethodSource("provideParams")
     public void handle_AlwaysReturn500InternalErrorWithStaticErrorCode(Throwable exception) {
         HandledException handled = handler.handle(exception);
 
@@ -44,7 +41,7 @@ public class LastResortWebErrorHandlerTest {
         assertThat(handled.getArguments()).isEmpty();
     }
 
-    private Object[] provideParams() {
+    private static Object[] provideParams() {
         return p(null, new RuntimeException(), new OutOfMemoryError());
     }
 }

--- a/src/test/java/me/alidg/errors/handlers/MissingRequestParametersWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/MissingRequestParametersWebErrorHandlerTest.java
@@ -1,11 +1,10 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MissingMatrixVariableException;
@@ -31,7 +30,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MissingRequestParametersWebErrorHandlerTest {
 
     /**
@@ -39,15 +38,15 @@ public class MissingRequestParametersWebErrorHandlerTest {
      */
     private final WebErrorHandler handler = new MissingRequestParametersWebErrorHandler();
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_ShouldReturnTrueForMissingRequestParamsErrors(Throwable exception, boolean expected) {
         assertThat(handler.canHandle(exception))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldHandleMissingRequestParamsErrorsProperly(Throwable exception,
                                                                       String expectedCode,
                                                                       HttpStatus expectedStatus,

--- a/src/test/java/me/alidg/errors/handlers/ResponseStatusWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/ResponseStatusWebErrorHandlerTest.java
@@ -1,11 +1,10 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpMethod;
@@ -32,7 +31,7 @@ import static org.springframework.http.MediaType.*;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ResponseStatusWebErrorHandlerTest {
 
     /**
@@ -40,15 +39,15 @@ public class ResponseStatusWebErrorHandlerTest {
      */
     private final ResponseStatusWebErrorHandler handler = new ResponseStatusWebErrorHandler();
 
-    @Test
-    @Parameters(method = "paramsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("paramsForCanHandle")
     public void canHandle_ShouldReturnTrueForResponseStatusExceptions(Exception e, boolean expected) {
         assertThat(handler.canHandle(e))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "paramsForHandle")
+    @ParameterizedTest
+    @MethodSource("paramsForHandle")
     public void handle_ShouldHandleResponseStatusExceptionsAppropriately(Exception e,
                                                                          String expectedErrorCode,
                                                                          HttpStatus expectedStatus,

--- a/src/test/java/me/alidg/errors/handlers/ServletWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/ServletWebErrorHandlerTest.java
@@ -1,10 +1,9 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.HandledException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -36,7 +35,7 @@ import static org.springframework.http.MediaType.*;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ServletWebErrorHandlerTest {
 
     /**
@@ -44,15 +43,15 @@ public class ServletWebErrorHandlerTest {
      */
     private final ServletWebErrorHandler handler = new ServletWebErrorHandler();
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_ShouldReturnTrueForSpringMvcSpecificErrors(Throwable exception, boolean expected) {
         assertThat(handler.canHandle(exception))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldHandleSpringMvcErrorsProperly(Throwable exception,
                                                            String expectedCode,
                                                            HttpStatus expectedStatus,

--- a/src/test/java/me/alidg/errors/handlers/SpringSecurityWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/SpringSecurityWebErrorHandlerTest.java
@@ -1,10 +1,9 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.HandledException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.*;
@@ -21,7 +20,7 @@ import static org.springframework.http.HttpStatus.*;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SpringSecurityWebErrorHandlerTest {
 
     /**
@@ -29,15 +28,15 @@ public class SpringSecurityWebErrorHandlerTest {
      */
     private final SpringSecurityWebErrorHandler handler = new SpringSecurityWebErrorHandler();
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_CanOnlyHandleSpringSecurityRelatedExceptions(Throwable exception, boolean expected) {
         assertThat(handler.canHandle(exception))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldHandleSecurityRelatedExceptionsProperly(Throwable exception,
                                                                      String expectedErrorCode,
                                                                      HttpStatus expectedStatusCode) {

--- a/src/test/java/me/alidg/errors/handlers/SpringValidationWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/SpringValidationWebErrorHandlerTest.java
@@ -1,11 +1,11 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.*;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SpringValidationWebErrorHandlerTest {
 
     /**
@@ -50,15 +50,15 @@ public class SpringValidationWebErrorHandlerTest {
         Validation.buildDefaultValidatorFactory().getValidator()
     );
 
-    @Test
-    @Parameters(method = "provideParamsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForCanHandle")
     public void canHandle_ShouldOnlyReturnTrueForSpringSpecificValidationErrors(Throwable exception, boolean expected) {
         assertThat(handler.canHandle(exception))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForHandle")
+    @ParameterizedTest
+    @MethodSource("provideParamsForHandle")
     public void handle_ShouldHandleTheValidationErrorsProperly(Object toValidate,
                                                                Set<String> errorCodes,
                                                                Map<String, List<Argument>> args) {

--- a/src/test/java/me/alidg/errors/handlers/TypeMismatchWebErrorHandlerTest.java
+++ b/src/test/java/me/alidg/errors/handlers/TypeMismatchWebErrorHandlerTest.java
@@ -1,12 +1,11 @@
 package me.alidg.errors.handlers;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
 import me.alidg.errors.HandledException;
 import me.alidg.errors.WebErrorHandler;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 
@@ -24,7 +23,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TypeMismatchWebErrorHandlerTest {
 
     /**
@@ -32,15 +31,15 @@ public class TypeMismatchWebErrorHandlerTest {
      */
     private final WebErrorHandler errorHandler = new TypeMismatchWebErrorHandler();
 
-    @Test
-    @Parameters(method = "paramsForCanHandle")
+    @ParameterizedTest
+    @MethodSource("paramsForCanHandle")
     public void canHandle_OnlyReturnsTrueForTypeMismatches(Exception ex, boolean expected) {
         assertThat(errorHandler.canHandle(ex))
             .isEqualTo(expected);
     }
 
-    @Test
-    @Parameters(method = "paramsForHandle")
+    @ParameterizedTest
+    @MethodSource("paramsForHandle")
     public void handle_ShouldHandleTypeMismatchExceptionsAppropriately(TypeMismatchException ex, List<Argument> arguments) {
         HandledException handledException = errorHandler.handle(ex);
 

--- a/src/test/java/me/alidg/errors/message/TemplateAwareMessageSourceIT.java
+++ b/src/test/java/me/alidg/errors/message/TemplateAwareMessageSourceIT.java
@@ -1,10 +1,9 @@
 package me.alidg.errors.message;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.Argument;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author zarebski-m
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TemplateAwareMessageSourceIT {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -35,8 +34,8 @@ public class TemplateAwareMessageSourceIT {
         return p(template, arguments, expectedMessage);
     }
 
-    @Test
-    @Parameters(method = "provideParamsForNamedArguments")
+    @ParameterizedTest
+    @MethodSource("provideParamsForNamedArguments")
     public void messageInterpolation_WithNamedArguments(String code,
                                                         List<Argument> arguments,
                                                         String expectedMessage) {

--- a/src/test/java/me/alidg/errors/mvc/ErrorsControllerAdviceTest.java
+++ b/src/test/java/me/alidg/errors/mvc/ErrorsControllerAdviceTest.java
@@ -1,11 +1,10 @@
 package me.alidg.errors.mvc;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import me.alidg.errors.WebErrorHandlers;
 import me.alidg.errors.adapter.HttpErrorAttributesAdapter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static me.alidg.Params.p;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,11 +15,11 @@ import static org.mockito.Mockito.mock;
  *
  * @author Ali Dehghani
  */
-@RunWith(JUnitParamsRunner.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ErrorsControllerAdviceTest {
 
-    @Test
-    @Parameters(method = "provideParamsForConstructor")
+    @ParameterizedTest
+    @MethodSource("provideParamsForConstructor")
     public void constructor_ShouldEnforceItsPreconditions(WebErrorHandlers handlers,
                                                           HttpErrorAttributesAdapter adapter,
                                                           String message) {

--- a/src/test/resources/test_messages.properties
+++ b/src/test/resources/test_messages.properties
@@ -2,6 +2,7 @@ range.limit=Between {1} and {0}
 number.min=The min is {0}
 text.required=The text is required
 invalid_params=Params are: {0}, {1} and {2}
+invalid_params_named=Params are: {min}, {legacyMax} and {theAnswer}
 web.missing_parameter=Parameter {name} of type {expected} is required
 web.missing_part={name} part is required
 web.unsupported_media_type={type} is not supported


### PR DESCRIPTION
After introduction of named arguments, argument order became less relevant. Unfortunately, existing annotation `@ExposeAsArg` required `int` argument that specifies the order. I find this too cumbersome, so I've decided to slightly rework this approach.

With this PR I introduce new annotation `@ExposeArg` with the following signature:

```java
public @interface ExposeArg {
    String value() default "";
    int order() default Integer.MAX_VALUE;
}
```

With this annotation, the default `value` argument represents exposed argument name, and its ordering was moved to argument `order`. Thanks to that, this annotation can be used without any argument.

Backwards compatibility is achieved by translation of `@ExposeAsArg` into `@ExposeArg` inside `AnnotatedWebErrorHandler`.