### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ install: true
 script:
   - ./mvnw clean verify sonar:sonar -Dsonar.projectKey=alimate_errors-spring-boot-starter -B
   - bash <(curl -s https://codecov.io/bash)
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.